### PR TITLE
Fixes an issue where the wrong files were being cleaned up

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,11 +31,20 @@ install: $(BIN_NAME)
 
 .PHONY: test
 test: $(TEST_IMAGES)
-	$(GO) test -v $(PACKAGE_PATHS)
+	@if [ -z $$T ]; then \
+		$(GO) test -v $(PACKAGE_PATHS); \
+	else \
+		$(GO) test -v $(PACKAGE_PATHS) -run $$T; \
+	fi
 
 .PHONY: system-test
 system-test: install $(TEST_IMAGES)
-	$(GO) test -v main_test.go
+	@if [ -z $$T ]; then \
+		$(GO) test -v main_test.go; \
+	else \
+		$(GO) test -v main_test.go -run $$T; \
+	fi
+	
 
 .PHONY: test-cover
 test-cover:

--- a/cmd/wp/image_caching.go
+++ b/cmd/wp/image_caching.go
@@ -121,7 +121,7 @@ func PrepareImageFromSource(sourcePath string, cacheDir string) (*ImageSource, e
 
 func CleanupImageSource(is *ImageSource) error {
 	if is.deleteParentDir {
-		return os.RemoveAll(path.Base(is.LocalPath))
+		return os.RemoveAll(path.Dir(is.LocalPath))
 	}
 
 	return nil

--- a/cmd/wp/image_caching_test.go
+++ b/cmd/wp/image_caching_test.go
@@ -80,3 +80,22 @@ func TestPrepareImageFromSourceRemote(t *testing.T) {
 	assert.Equal(t, "square.jpg", path.Base(is.LocalPath))
 	CleanupImageSource(is)
 }
+
+func TestCleanupImageSource(t *testing.T) {
+	cwd, _ := os.Getwd()
+	sourceImage, err := filepath.Abs(path.Join(cwd, "..", "..", "test_images", "square.jpg"))
+	assert.NoError(t, err)
+
+	is, err := PrepareImageFromSource(sourceImage, "")
+	assert.NoError(t, err)
+
+	assert.Equal(t, "square.jpg", path.Base(is.LocalPath))
+	CleanupImageSource(is)
+
+	_, err = os.Stat(filepath.Dir(is.LocalPath))
+
+	e, ok := err.(*os.PathError)
+	assert.True(t, ok)
+	assert.NotNil(t, e)
+	assert.True(t, os.IsNotExist(e))
+}

--- a/main_test.go
+++ b/main_test.go
@@ -267,3 +267,49 @@ func TestPickImageScaled(t *testing.T) {
 
 	assert.Equal(t, expectedOutput, string(output))
 }
+
+// This test exists for historical purposes.
+// There was once an issue where image extractions where the source image is
+//   in the current working directory lead to the image being removed.
+func TestPickFromThisDirectory(t *testing.T) {
+	cwd, _ := os.Getwd()
+		
+	originalImage, _ := filepath.Abs(path.Join(cwd, "test_images", "square.jpg"))
+	sourceImage, _ := filepath.Abs(path.Join(cwd, "square.jpg"))
+
+	// Copy square.jpg from test images to the current working dir.
+	source, err := os.Open(originalImage)
+	assert.NoError(t, err)
+
+	destination, err := os.Create(sourceImage)
+	assert.NoError(t, err)
+
+	_, err = io.Copy(destination, source)
+	source.Close()
+	destination.Close()
+
+	tempDir, err := ioutil.TempDir("", "")
+	assert.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	cmd := exec.Command("wp", "pick", "128x128", tempDir, "north", sourceImage)
+
+	output, err := cmd.CombinedOutput()
+	assert.NoError(t, err)
+
+	filenameSuffixes := []string{
+		"north",
+	}
+
+	expectedOutput := ""
+	for _, str := range filenameSuffixes {
+		expectedOutput += path.Join(tempDir, "128x128", "square_"+str) + ".jpg\n"
+	}
+
+	assert.Equal(t, expectedOutput, string(output))
+
+	_, err = os.Stat(sourceImage)
+	assert.NoError(t, err)
+
+	os.Remove(sourceImage)
+}

--- a/main_test.go
+++ b/main_test.go
@@ -131,7 +131,8 @@ func TestExtractMultipleImages(t *testing.T) {
 }
 
 // This test exists for historical purposes.
-// There was once an issue where image extractions from the 
+// There was once an issue where image extractions where the source image is
+//   in the current working directory lead to the image being removed.
 func TestExtractFromThisDirectory(t *testing.T) {
 	cwd, _ := os.Getwd()
 		
@@ -180,6 +181,8 @@ func TestExtractFromThisDirectory(t *testing.T) {
 
 	_, err = os.Stat(sourceImage)
 	assert.NoError(t, err)
+
+	os.Remove(sourceImage)
 }
 
 func TestPickImage(t *testing.T) {


### PR DESCRIPTION
Error was cleaning up `filepath.Base`, rather than `filepath.Dir`. 