### PR TITLE
Prevent "caching" files that already live in the cache directory

### DIFF
--- a/pkg/wp/image_caching.go
+++ b/pkg/wp/image_caching.go
@@ -72,6 +72,7 @@ func PrepareImageFromSource(sourcePath string, cacheDir string) (*ImageSource, e
 	// If the SourcePath is rooted in the cache directory, bail early, because
 	//   there's nothing interesting to do, and trying to use any kind of
 	//   recaching logic will just duplicate the image in the cache directory.
+	// Doesn't obey obey symlinks, for now.
 	if cacheDir != "" {
 		isLocal, err := is.SourcePathIsLocal()
 		if err != nil {

--- a/pkg/wp/image_caching_test.go
+++ b/pkg/wp/image_caching_test.go
@@ -43,6 +43,23 @@ func TestPrepareImageFromSourceLocalCached(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestPrepareImageFromSourceLocalCachedInCacheDir(t *testing.T) {
+	cwd, _ := os.Getwd()
+	projectRoot, err := filepath.Abs(path.Join(cwd, "..", ".."))
+	assert.NoError(t, err)
+	sourceImage, err := filepath.Abs(path.Join(projectRoot, "test_images", "square.jpg"))
+	assert.NoError(t, err)
+
+	is, err := PrepareImageFromSource(sourceImage, projectRoot)
+	assert.NoError(t, err)
+
+	assert.Equal(t, is.SourcePath, is.LocalPath)
+	CleanupImageSource(is)
+
+	_, err = os.Stat(is.LocalPath)
+	assert.NoError(t, err)
+}
+
 func TestPrepareImageFromSourceLocalWithProtocol(t *testing.T) {
 	cwd, _ := os.Getwd()
 	sourceImage, err := filepath.Abs(path.Join(cwd, "..", "..", "test_images", "square.jpg"))


### PR DESCRIPTION
As of right now, if a file is processed that exists within the cache directory, it will be re-cached. 

This leads to duplicates in the best case, and in the case where the file is the same, possibly attempts to copy to itself in a bad way? 

This adds a check to see if the file being processed is rooted in the cache directory, and if it is, the file isn't copied/moved anywhere, it's left where it is, and processed from there.